### PR TITLE
`Notifications`: Add new iOS notification api

### DIFF
--- a/common/src/main/java/de/tum/cit/artemis/push/common/NotificationRequest.java
+++ b/common/src/main/java/de/tum/cit/artemis/push/common/NotificationRequest.java
@@ -1,4 +1,4 @@
 package de.tum.cit.artemis.push.common;
 
-public record NotificationRequest(String initializationVector, String payloadCipherText, String token) {
+public record NotificationRequest(String initializationVector, String payloadCipherText, String token, PushNotificationApiType apiType) {
 }

--- a/common/src/main/java/de/tum/cit/artemis/push/common/PushNotificationApiType.java
+++ b/common/src/main/java/de/tum/cit/artemis/push/common/PushNotificationApiType.java
@@ -1,0 +1,23 @@
+package de.tum.cit.artemis.push.common;
+
+import java.util.Arrays;
+
+public enum PushNotificationApiType {
+
+    DEFAULT((short) 0), IOS_V2((short) 1);
+
+    private final short databaseKey;
+
+    PushNotificationApiType(short databaseKey) {
+        this.databaseKey = databaseKey;
+    }
+
+    public short getDatabaseKey() {
+        return databaseKey;
+    }
+
+    public static PushNotificationApiType fromDatabaseKey(short databaseKey) {
+        return Arrays.stream(PushNotificationApiType.values()).filter(type -> type.getDatabaseKey() == databaseKey).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown database key: " + databaseKey));
+    }
+}


### PR DESCRIPTION
### Motivation
Currently, the notifications in iOS are running as background notifications. To change this, we need to send different payloads to iOS18 devices, while keeping the iOS17 and lower devices the same.

### Description
The artemis server will now send a api version of the device. To react to this I have changed the apns service to read this new value and update the payload accordingly (content type = false, mutable content = true, a default alert body, and PushType.ALERT).

